### PR TITLE
cloudflare-dyndns: Implement env substitution for config

### DIFF
--- a/apps/cloudflare-dyndns/README.md
+++ b/apps/cloudflare-dyndns/README.md
@@ -46,6 +46,8 @@ Output of `cloudflare-dyndns -h`
 Usage of cloudflare-dyndns:
   -config string
         Path to config file, can be empty when running in mode server
+  -env
+        Used together with -config, when set will expand enviroment variables in config
   -mode string
         Set what mode to run, options are "server", "client" and "relay" (default "server")
 ```

--- a/apps/cloudflare-dyndns/cmd/main.go
+++ b/apps/cloudflare-dyndns/cmd/main.go
@@ -15,18 +15,20 @@ import (
 var (
 	mode       string
 	configPath string
+	env        bool
 )
 
 // Initialize the needed flags for cli options
 func init() {
 	flag.StringVar(&mode, "mode", config.MODE_SERVER, "Set what mode to run, options are \""+config.MODE_SERVER+"\", \""+config.MODE_CLIENT+"\" and \""+config.MODE_RELAY+"\"")
 	flag.StringVar(&configPath, "config", "", "Path to config file, can be empty when running in mode "+config.MODE_SERVER)
+	flag.BoolVar(&env, "env", false, "Used together with -config, when set will expand enviroment variables in config")
 }
 
 func main() {
 	flag.Parse()
 
-	cfg, err := config.LoadConfig(configPath, mode)
+	cfg, err := config.LoadConfig(configPath, mode, env)
 	if err != nil {
 		slog.Error("Could not load configuration", slog.String("path", configPath), slog.String("err", err.Error()))
 		os.Exit(1)

--- a/apps/cloudflare-dyndns/cmd/main.go
+++ b/apps/cloudflare-dyndns/cmd/main.go
@@ -41,14 +41,14 @@ func main() {
 			os.Exit(1)
 		}
 	case config.MODE_CLIENT:
-		c, err := client.NewCloudflareClient(cfg.Client.Secret, cfg.Client.Proxy)
+		c, err := client.NewCloudflareClient(cfg.Client.Token, cfg.Client.Proxy)
 		if err != nil {
 			slog.Error("Could not create new client", "err", err)
 			os.Exit(1)
 		}
 		runClient(c, cfg.Client)
 	case config.MODE_RELAY:
-		r, err := relay.NewRelay(cfg.Client.Secret, cfg.Client.Proxy, cfg.Client.Endpoint)
+		r, err := relay.NewRelay(cfg.Client.Token, cfg.Client.Proxy, cfg.Client.Endpoint)
 		if err != nil {
 			slog.Error("Could not create new client", "err", err)
 			os.Exit(1)

--- a/apps/cloudflare-dyndns/configs/example-config.yaml
+++ b/apps/cloudflare-dyndns/configs/example-config.yaml
@@ -13,7 +13,7 @@ server:
 # Config for running in client mode
 client:
   # Token for accessing the cloudflare api
-  secret: ""
+  token: ""
   # Indicate if entries should be proxied by cloudflare. Default: true
   proxy: true
   # List of domains to update

--- a/apps/cloudflare-dyndns/pkg/client/client.go
+++ b/apps/cloudflare-dyndns/pkg/client/client.go
@@ -24,7 +24,7 @@ type cloudflareClient struct {
 // Create a new CloudflareClient and test if the token is valid
 func NewCloudflareClient(token string, proxy bool) (dyndns.Client, error) {
 	if token == "" {
-		return nil, dyndns.ErrMissingSecret{}
+		return nil, dyndns.ErrMissingToken{}
 	}
 
 	c := &cloudflareClient{

--- a/apps/cloudflare-dyndns/pkg/client/client_test.go
+++ b/apps/cloudflare-dyndns/pkg/client/client_test.go
@@ -10,13 +10,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// Only test missing secret is checked, login is tested separately
+// Only test missing token is checked, login is tested separately
 func TestNewCloudflareClient(t *testing.T) {
 	c, err := NewCloudflareClient("", true)
 
 	assert := assert.New(t)
 
-	assert.Equal(dyndns.ErrMissingSecret{}, err)
+	assert.Equal(dyndns.ErrMissingToken{}, err)
 	assert.Nil(c)
 }
 

--- a/apps/cloudflare-dyndns/pkg/config/config.go
+++ b/apps/cloudflare-dyndns/pkg/config/config.go
@@ -95,7 +95,12 @@ func DefaultConfig() Config {
 }
 
 // Loads config from file, returns error if config is invalid
-func LoadConfig(path string, mode string) (Config, error) {
+// Arguments:
+//
+//	path: Path to config file
+//	mode: Mode used, determines how the config will be validated and which values will be processed
+//	env: Determines if enviroment variables in the file will be expanded before decoding
+func LoadConfig(path string, mode string, env bool) (Config, error) {
 	c := DefaultConfig()
 
 	if path == "" && mode == MODE_SERVER {
@@ -103,15 +108,16 @@ func LoadConfig(path string, mode string) (Config, error) {
 		return c, nil
 	}
 
-	f, err := os.Open(path)
+	f, err := os.ReadFile(path)
 	if err != nil {
 		return Config{}, err
 	}
-	defer f.Close()
 
-	d := yaml.NewDecoder(f)
+	if env {
+		f = []byte(os.ExpandEnv(string(f)))
+	}
 
-	err = d.Decode(&c)
+	err = yaml.Unmarshal(f, &c)
 	if err != nil {
 		return Config{}, err
 	}

--- a/apps/cloudflare-dyndns/pkg/config/config.go
+++ b/apps/cloudflare-dyndns/pkg/config/config.go
@@ -45,7 +45,7 @@ type ServerConfig struct {
 
 // Yaml configuration for dyndns client
 type ClientConfig struct {
-	Secret       string        `yaml:"secret"`
+	Token        string        `yaml:"token"`
 	Proxy        bool          `yaml:"proxy,omitempty"`
 	Domains      []string      `yaml:"domains"`
 	Interval     string        `yaml:"interval,omitempty"`
@@ -55,8 +55,8 @@ type ClientConfig struct {
 
 // Validate the client part of the config
 func (c *Config) validateClient() error {
-	if c.Client.Secret == "" {
-		return dyndns.ErrMissingSecret{}
+	if c.Client.Token == "" {
+		return dyndns.ErrMissingToken{}
 	}
 
 	if c.Client.Domains == nil || len(c.Client.Domains) < 1 {

--- a/apps/cloudflare-dyndns/pkg/config/config_test.go
+++ b/apps/cloudflare-dyndns/pkg/config/config_test.go
@@ -17,7 +17,7 @@ func TestValidConfigs(t *testing.T) {
 			Domains: []string{"example.org", "example.net"},
 		},
 		Client: ClientConfig{
-			Secret:       "test-token-1",
+			Token:        "test-token-1",
 			Proxy:        true,
 			Domains:      []string{"foo.example.org"},
 			Interval:     "5m",
@@ -32,7 +32,7 @@ func TestValidConfigs(t *testing.T) {
 			Domains: []string{"example.com"},
 		},
 		Client: ClientConfig{
-			Secret:       "test-token-2",
+			Token:        "test-token-2",
 			Proxy:        false,
 			Domains:      []string{"bar.example.net"},
 			Interval:     "10m",
@@ -121,10 +121,10 @@ func TestInvalidConfig(t *testing.T) {
 			Error: "*yaml.TypeError",
 		},
 		{
-			Name:  "ClientMissingSecret",
+			Name:  "ClientMissingToken",
 			Mode:  MODE_CLIENT,
 			Path:  "testdata/invalid-config-1.yaml",
-			Error: "dyndns.ErrMissingSecret",
+			Error: "dyndns.ErrMissingToken",
 		},
 		{
 			Name:  "ClientNoDomain",
@@ -145,10 +145,10 @@ func TestInvalidConfig(t *testing.T) {
 			Error: "*config.ErrInvalidInterval",
 		},
 		{
-			Name:  "RelayMissingSecret",
+			Name:  "RelayMissingToken",
 			Mode:  MODE_RELAY,
 			Path:  "testdata/invalid-config-1.yaml",
-			Error: "dyndns.ErrMissingSecret",
+			Error: "dyndns.ErrMissingToken",
 		},
 		{
 			Name:  "RelayNoDomain",

--- a/apps/cloudflare-dyndns/pkg/config/testdata/env-config.yaml
+++ b/apps/cloudflare-dyndns/pkg/config/testdata/env-config.yaml
@@ -1,0 +1,25 @@
+# Log level of the application
+logLevel: "${DYNDNS_TEST_LOG_LEVEL}"
+
+# Config for running in server mode
+server:
+  # Port to listen on. Default: 8080
+  port: ${DYNDNS_TEST_SERVER_PORT}
+  # List of root domains that are allowed to be updated. Allows all when empty.
+  domains:
+    - "${DYNDNS_TEST_SERVER_DOMAIN1}"
+    - "${DYNDNS_TEST_SERVER_DOMAIN2}"
+
+# Config for running in client mode
+client:
+  # Token for accessing the cloudflare api
+  token: "${DYNDNS_TEST_CLIENT_TOKEN}"
+  # Indicate if entries should be proxied by cloudflare. Default: true
+  proxy: ${DYNDNS_TEST_CLIENT_PROXY}
+  # List of domains to update
+  domains:
+    - "${DYNDNS_TEST_CLIENT_DOMAIN}"
+  # Interval in which the client should check for ip changes. Default: 5m
+  interval: "${DYNDNS_TEST_CLIENT_INTERVAL}"
+  # Endpoint to call when using relay mode
+  endpoint: "${DYNDNS_TEST_CLIENT_ENDPOINT}"

--- a/apps/cloudflare-dyndns/pkg/config/testdata/invalid-config-1.yaml
+++ b/apps/cloudflare-dyndns/pkg/config/testdata/invalid-config-1.yaml
@@ -1,6 +1,6 @@
 # Fails because of no token
 client:
-  secret: ""
+  token: ""
   proxy: true
   domains:
     - foo.example.org

--- a/apps/cloudflare-dyndns/pkg/config/testdata/invalid-config-2.yaml
+++ b/apps/cloudflare-dyndns/pkg/config/testdata/invalid-config-2.yaml
@@ -1,6 +1,6 @@
 # Fails because of no domains
 client:
-  secret: "testsecret"
+  token: "testtoken"
   proxy: true
   interval: "5m"
   endpoint: "https://dyndns.example.org"

--- a/apps/cloudflare-dyndns/pkg/config/testdata/invalid-config-3.yaml
+++ b/apps/cloudflare-dyndns/pkg/config/testdata/invalid-config-3.yaml
@@ -1,6 +1,6 @@
 # Fails because of invalid interval format
 client:
-  secret: "testsecret"
+  token: "testtoken"
   proxy: true
   domains:
     - foo.example.org

--- a/apps/cloudflare-dyndns/pkg/config/testdata/invalid-config-4.yaml
+++ b/apps/cloudflare-dyndns/pkg/config/testdata/invalid-config-4.yaml
@@ -1,6 +1,6 @@
 # Fails in relay mode because of missing endpoint
 client:
-  secret: "testsecret"
+  token: "testtoken"
   proxy: true
   domains:
     - foo.example.org

--- a/apps/cloudflare-dyndns/pkg/config/testdata/invalid-config-5.yaml
+++ b/apps/cloudflare-dyndns/pkg/config/testdata/invalid-config-5.yaml
@@ -1,6 +1,6 @@
 # Fails because interval is to small
 client:
-  secret: "testsecret"
+  token: "testtoken"
   proxy: true
   domains:
     - foo.example.org

--- a/apps/cloudflare-dyndns/pkg/config/testdata/valid-config-1.yaml
+++ b/apps/cloudflare-dyndns/pkg/config/testdata/valid-config-1.yaml
@@ -13,7 +13,7 @@ server:
 # Config for running in client mode
 client:
   # Token for accessing the cloudflare api
-  secret: "test-token-1"
+  token: "test-token-1"
   # Indicate if entries should be proxied by cloudflare. Default: true
   proxy: true
   # List of domains to update

--- a/apps/cloudflare-dyndns/pkg/config/testdata/valid-config-2.yaml
+++ b/apps/cloudflare-dyndns/pkg/config/testdata/valid-config-2.yaml
@@ -12,7 +12,7 @@ server:
 # Config for running in client mode
 client:
   # Token for accessing the cloudflare api
-  secret: "test-token-2"
+  token: "test-token-2"
   # Indicate if entries should be proxied by cloudflare. Default: true
   proxy: false
   # List of domains to update

--- a/apps/cloudflare-dyndns/pkg/dyndns/errors.go
+++ b/apps/cloudflare-dyndns/pkg/dyndns/errors.go
@@ -5,10 +5,10 @@ import (
 	"io"
 )
 
-type ErrMissingSecret struct{}
+type ErrMissingToken struct{}
 
-func (e ErrMissingSecret) Error() string {
-	return "No secret provided for authenticating with the API."
+func (e ErrMissingToken) Error() string {
+	return "No token provided for authenticating with the API."
 }
 
 type ErrMissingEndpoint struct{}

--- a/apps/cloudflare-dyndns/pkg/dyndns/testclient.go
+++ b/apps/cloudflare-dyndns/pkg/dyndns/testclient.go
@@ -13,7 +13,7 @@ type testClient struct {
 // Create a new testClient, fails if the token is empty
 func NewTestClient(token string, proxy bool) (Client, error) {
 	if token == "" {
-		return nil, ErrMissingSecret{}
+		return nil, ErrMissingToken{}
 	}
 	return &testClient{
 		data:       NewClientData(proxy),

--- a/apps/cloudflare-dyndns/pkg/relay/relay.go
+++ b/apps/cloudflare-dyndns/pkg/relay/relay.go
@@ -19,7 +19,7 @@ type relay struct {
 // Create a new Relay
 func NewRelay(token string, proxy bool, endpoint string) (dyndns.Client, error) {
 	if token == "" {
-		return nil, dyndns.ErrMissingSecret{}
+		return nil, dyndns.ErrMissingToken{}
 	}
 	if endpoint == "" {
 		return nil, dyndns.ErrMissingEndpoint{}

--- a/apps/cloudflare-dyndns/pkg/relay/relay_test.go
+++ b/apps/cloudflare-dyndns/pkg/relay/relay_test.go
@@ -16,7 +16,7 @@ func TestNewRelayClient(t *testing.T) {
 
 	assert := assert.New(t)
 
-	assert.Equal(dyndns.ErrMissingSecret{}, err)
+	assert.Equal(dyndns.ErrMissingToken{}, err)
 	assert.Nil(c)
 
 	c, err = NewRelay("testtoken", true, "")


### PR DESCRIPTION
Add option to substitute values in the config file from Env when reading it.

Rename secret to token in config for consitency with API