### PR TITLE
minecraft-exporter: Fix wrong return on player_online for 1.20

### DIFF
--- a/apps/minecraft-exporter/pkg/rcon/rcon.go
+++ b/apps/minecraft-exporter/pkg/rcon/rcon.go
@@ -54,7 +54,7 @@ func (c *RCONClient) cmd(cmd string) (string, error) {
 		}
 	}
 
-	slog.Debug("Running RCON command", "cmd", cmd)
+	slog.Debug("RCON: Running command", "cmd", cmd)
 
 	timeout := time.After(time.Second)
 	done := make(chan bool)
@@ -79,6 +79,7 @@ func (c *RCONClient) cmd(cmd string) (string, error) {
 			_ = c.CloseConn()
 			return
 		}
+		slog.Debug("RCON: Received response", "cmd", cmd, "res", res)
 	}()
 
 	select {

--- a/apps/minecraft-exporter/pkg/rcon/utils.go
+++ b/apps/minecraft-exporter/pkg/rcon/utils.go
@@ -13,7 +13,7 @@ import (
 // Parse the output of the list command
 func parsePlayersOnline(input string) []string {
 	s := strings.Split(input, "players online: ")
-	if len(s) < 2 {
+	if len(s) < 2 || s[1] == "" {
 		return []string{}
 	}
 

--- a/apps/minecraft-exporter/pkg/rcon/utils_test.go
+++ b/apps/minecraft-exporter/pkg/rcon/utils_test.go
@@ -12,7 +12,9 @@ func TestParsePlayersOnline(t *testing.T) {
 		Players     []string
 	}{
 		{"1.12", "There are 0/10 players online: Foo1234, Bar5678", []string{"Foo1234", "Bar5678"}},
+		{"1.12-empty", "There are 0/10 players online:", []string{}},
 		{"1.20", "There are 0 of a max of 20 players online: Foo1234, Bar5678", []string{"Foo1234", "Bar5678"}},
+		{"1.20-empty", "There are 0 of a max of 20 players online: ", []string{}},
 	}
 
 	for _, tCase := range tMatrix {


### PR DESCRIPTION
When no players are online, 1.20 would return an emtpy string as player list,
resulting in an "empty" metric.

Always log full RCON commands in debug mode.