### PR TITLE
Renovate: Disable autoMerge for minor/patch when major version is zero

### DIFF
--- a/.github/renovate/autoMerge.json5
+++ b/.github/renovate/autoMerge.json5
@@ -15,7 +15,8 @@
       "matchDatasources": ["github-tags"],
       "automerge": true,
       "automergeType": "branch",
-      "matchUpdateTypes": ["minor", "patch"]
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchCurrentVersion": "!/^0/",
     },
     {
       "description": "Auto merge GitHub Actions (Docker)",
@@ -23,7 +24,8 @@
       "matchFileNames": [".github/workflows/*.yaml", ".github/workflows/*.yml"],
       "automerge": true,
       "automergeType": "branch",
-      "matchUpdateTypes": ["minor", "patch"]
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchCurrentVersion": "!/^0/",
     },
     {
       "description": "Auto merge Bitwarden CLI",


### PR DESCRIPTION
The matchCurrentVersion setting above is a rule to exclude any dependencies which are pre-1.0.0 because those can make breaking changes at any time according to the SemVer spec.