### PR TITLE
fcos-k8s: Update upgraded to v0.4.2

### DIFF
--- a/apps/fcos-k8s/Dockerfile
+++ b/apps/fcos-k8s/Dockerfile
@@ -7,7 +7,7 @@ ENV KUBERNETES_VERSION=1.32.0
 ENV CRIO_VERSION=1.31
 
 # renovate: datasource=github-releases depName=heathcliff26/kube-upgrade extractVersion=^(?<version>.*)$
-ENV KUBE_UPGRADE_VERSION=v0.4.1
+ENV KUBE_UPGRADE_VERSION=v0.4.2
 
 COPY k8s-install.sh upgraded.service /var/kubernetes/
 

--- a/apps/fcos-k8s/Dockerfile.v1.30
+++ b/apps/fcos-k8s/Dockerfile.v1.30
@@ -6,7 +6,7 @@ ENV KUBERNETES_VERSION=1.30.8
 ENV CRIO_VERSION=1.30
 
 # renovate: datasource=github-releases depName=heathcliff26/kube-upgrade extractVersion=^(?<version>.*)$
-ENV KUBE_UPGRADE_VERSION=v0.4.1
+ENV KUBE_UPGRADE_VERSION=v0.4.2
 
 COPY k8s-install.sh upgraded.service /var/kubernetes/
 

--- a/apps/fcos-k8s/Dockerfile.v1.31
+++ b/apps/fcos-k8s/Dockerfile.v1.31
@@ -6,7 +6,7 @@ ENV KUBERNETES_VERSION=1.31.4
 ENV CRIO_VERSION=1.31
 
 # renovate: datasource=github-releases depName=heathcliff26/kube-upgrade extractVersion=^(?<version>.*)$
-ENV KUBE_UPGRADE_VERSION=v0.4.1
+ENV KUBE_UPGRADE_VERSION=v0.4.2
 
 COPY k8s-install.sh upgraded.service /var/kubernetes/
 


### PR DESCRIPTION
Fix an issue with k8s 1.32 permissions by upgrading upgraded to a fixed version.