### PR TITLE
go-fyne-ci: Fix build warning

### DIFF
--- a/apps/go-fyne-ci/Dockerfile
+++ b/apps/go-fyne-ci/Dockerfile
@@ -22,7 +22,7 @@ RUN set -eux; \
     rm -r /var/lib/apt/lists/*;
 
 # Add zig to path
-ENV PATH /usr/local/zig:$PATH
+ENV PATH=/usr/local/zig:$PATH
 
 # Install Zig
 RUN set -eux; \


### PR DESCRIPTION
Fix legacy whitespace separator in ENV arg.