### PR TITLE
fcos-k8s: Drop coreos version tags

### DIFF
--- a/.github/workflows/build-fcos-k8s-v1.30.yaml
+++ b/.github/workflows/build-fcos-k8s-v1.30.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Extract kubernetes and fcos version
+      - name: Extract kubernetes version
         id: version
         run: |
           set -ex
@@ -42,10 +42,6 @@ jobs:
           VERSION="$(echo "${VERSION_STRING}" | awk -F'=' '{print $2}' | tr -d '"')"
           echo "kubernetes-version=v${VERSION}" >> "$GITHUB_OUTPUT"
           echo "kubernetes-short-version=v${VERSION%.*}" >> "$GITHUB_OUTPUT"
-          CONTAINER_IMAGE="$(grep "FROM quay.io/fedora/fedora-coreos" apps/fcos-k8s/Dockerfile.v1.30 | awk -F' ' '{print $2}')"
-          podman run -t "${CONTAINER_IMAGE}" cat /etc/os-release > os-release
-          source os-release
-          echo "fcos-version=${OSTREE_VERSION}" >> "$GITHUB_OUTPUT"
 
   build:
     uses: heathcliff26/ci/.github/workflows/build-container.yaml@main
@@ -57,8 +53,7 @@ jobs:
       app: fcos-k8s
       tag: "${{ needs.metadata.outputs.kubernetes-short-version }}"
       tags: |
-        ${{ needs.metadata.outputs.kubernetes-version }}"
-        "${{ needs.metadata.outputs.kubernetes-version }}-${{ needs.metadata.outputs.fcos-version }}
+        ${{ needs.metadata.outputs.kubernetes-version }}
       dry-run: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
       context: apps/fcos-k8s
       dockerfile: Dockerfile.v1.30

--- a/.github/workflows/build-fcos-k8s-v1.31.yaml
+++ b/.github/workflows/build-fcos-k8s-v1.31.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Extract kubernetes and fcos version
+      - name: Extract kubernetes version
         id: version
         run: |
           set -ex
@@ -42,10 +42,6 @@ jobs:
           VERSION="$(echo "${VERSION_STRING}" | awk -F'=' '{print $2}' | tr -d '"')"
           echo "kubernetes-version=v${VERSION}" >> "$GITHUB_OUTPUT"
           echo "kubernetes-short-version=v${VERSION%.*}" >> "$GITHUB_OUTPUT"
-          CONTAINER_IMAGE="$(grep "FROM quay.io/fedora/fedora-coreos" apps/fcos-k8s/Dockerfile.v1.31 | awk -F' ' '{print $2}')"
-          podman run -t "${CONTAINER_IMAGE}" cat /etc/os-release > os-release
-          source os-release
-          echo "fcos-version=${OSTREE_VERSION}" >> "$GITHUB_OUTPUT"
 
   build:
     uses: heathcliff26/ci/.github/workflows/build-container.yaml@main
@@ -57,8 +53,7 @@ jobs:
       app: fcos-k8s
       tag: "${{ needs.metadata.outputs.kubernetes-short-version }}"
       tags: |
-        ${{ needs.metadata.outputs.kubernetes-version }}"
-        "${{ needs.metadata.outputs.kubernetes-version }}-${{ needs.metadata.outputs.fcos-version }}
+        ${{ needs.metadata.outputs.kubernetes-version }}
       dry-run: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
       context: apps/fcos-k8s
       dockerfile: Dockerfile.v1.31

--- a/.github/workflows/build-fcos-k8s.yaml
+++ b/.github/workflows/build-fcos-k8s.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Extract kubernetes and fcos version
+      - name: Extract kubernetes version
         id: version
         run: |
           set -ex
@@ -42,10 +42,6 @@ jobs:
           VERSION="$(echo "${VERSION_STRING}" | awk -F'=' '{print $2}' | tr -d '"')"
           echo "kubernetes-version=v${VERSION}" >> "$GITHUB_OUTPUT"
           echo "kubernetes-short-version=v${VERSION%.*}" >> "$GITHUB_OUTPUT"
-          CONTAINER_IMAGE="$(grep "FROM quay.io/fedora/fedora-coreos" apps/fcos-k8s/Dockerfile | awk -F' ' '{print $2}')"
-          podman run -t "${CONTAINER_IMAGE}" cat /etc/os-release > os-release
-          source os-release
-          echo "fcos-version=${OSTREE_VERSION}" >> "$GITHUB_OUTPUT"
 
   build:
     uses: heathcliff26/ci/.github/workflows/build-container.yaml@main
@@ -58,7 +54,6 @@ jobs:
       tag: "${{ needs.metadata.outputs.kubernetes-short-version }}"
       tags: |
         ${{ needs.metadata.outputs.kubernetes-version }}"
-        "${{ needs.metadata.outputs.kubernetes-version }}-${{ needs.metadata.outputs.fcos-version }}"
         "type=raw,value=latest,enable={{is_default_branch}}
       dry-run: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
       context: apps/fcos-k8s


### PR DESCRIPTION
Since Fedora CoreOS is a rolling release, there is no need to keep the tags for the fcos version. Drop them to make cleaning up the container images easier.