### PR TITLE
Revert "go-fyne-ci: Switch fyne cli to tools directory"

### DIFF
--- a/apps/go-fyne-ci/Dockerfile
+++ b/apps/go-fyne-ci/Dockerfile
@@ -4,8 +4,8 @@ FROM docker.io/library/golang:1.24.3@sha256:39d9e7d9c5d9c9e4baf0d8fff579f06d5032
 ARG GOLANGCI_LINT_VERSION=v2.1.6
 # renovate: datasource=github-releases depName=ziglang/zig
 ARG ZIG_VERSION=0.14.0
-# renovate: datasource=github-tags depName=fyne-io/tools
-ARG FYNE_CLI_VERSION=v1.6.1
+# renovate: datasource=github-releases depName=fyne-io/fyne
+ARG FYNE_VERSION=v2.6.1
 # renovate: datasource=github-releases depName=boxboat/fixuid
 ARG FIXUID_VERSION=0.6.0
 
@@ -52,8 +52,9 @@ RUN set -eux; \
 
 # Install the fyne CLI tool
 RUN set -eux; \
-    go install -ldflags="-s" -v "fyne.io/tools/cmd/fyne@${FYNE_CLI_VERSION}"; \
+    go install -ldflags="-s" -v "fyne.io/fyne/v2/cmd/fyne@${FYNE_VERSION}"; \
     mv /go/bin/fyne /usr/local/bin/fyne; \
+    fyne version; \
     go clean -cache -modcache; \
     mkdir -p "$GOPATH/pkg/mod" && chmod -R 777 "$GOPATH"
 


### PR DESCRIPTION
Turns out fyne-cross is not compatible with the new cli at the moment.

This reverts commit e63d5bfc7576499ce4a65ed6fc5e777f1dff7aaf.