### PR TITLE
default-webpage: Remove nginx variant

### DIFF
--- a/.github/workflows/build-default-webpage.yaml
+++ b/.github/workflows/build-default-webpage.yaml
@@ -21,7 +21,7 @@ on:
     branches: ["main"]
 
 jobs:
-  build-tiny:
+  build:
     uses: heathcliff26/ci/.github/workflows/build-container.yaml@main
     permissions:
       contents: read
@@ -29,24 +29,7 @@ jobs:
     with:
       app: default-webpage
       dockerfile: Dockerfile
-      tag: slim
-      tags: |
-        rolling"
-        "type=raw,value=latest,enable={{is_default_branch}}
-      dry-run: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
-      context: apps/default-webpage
-    secrets: inherit
-
-  build-nginx:
-    uses: heathcliff26/ci/.github/workflows/build-container.yaml@main
-    permissions:
-      contents: read
-      packages: write
-    with:
-      app: default-webpage
-      dockerfile: Dockerfile.nginx
-      tag: nginx
-      tags: ""
+      tag: rolling
       dry-run: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
       context: apps/default-webpage
     secrets: inherit

--- a/apps/default-webpage/Dockerfile
+++ b/apps/default-webpage/Dockerfile
@@ -1,5 +1,11 @@
 FROM ghcr.io/heathcliff26/simple-fileserver:v1.2.11@sha256:ea2dc6fba49c5d5a5ccd77f6459efa53e6a01dd973854a6fab329296a64814fb
 
+LABEL   org.opencontainers.image.authors="heathcliff@heathcliff.eu" \
+        org.opencontainers.image.description="Placeholder webpage served with simple-fileserver" \
+        org.opencontainers.image.source="https://github.com/heathcliff26/containers/tree/main/apps/default-webpage" \
+        org.opencontainers.image.licenses="Apache-2.0" \
+        org.opencontainers.image.title="default-webpage"
+
 ENV SFILESERVER_NO_INDEX="true"
 
 COPY --chown=1001:1001 --chmod=644 index.html /webroot/

--- a/apps/default-webpage/Dockerfile.nginx
+++ b/apps/default-webpage/Dockerfile.nginx
@@ -1,4 +1,0 @@
-FROM docker.io/nginxinc/nginx-unprivileged:1.29.1@sha256:6eb1d841743d6f4f48104a025f696942bd6f331b847f69f1dd925ae299f53a62
-
-COPY --chown=nginx:nginx --chmod=644 index.html /usr/share/nginx/html/
-COPY --chown=nginx:nginx --chmod=644 kundenumfrage /usr/share/nginx/html/kundenumfrage


### PR DESCRIPTION
The nginx image variant is no longer used. Remove it.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>