### PR TITLE
fcos-k8s: Disable systemd-resolved

### DIFF
--- a/apps/fcos-k8s/k8s-install.sh
+++ b/apps/fcos-k8s/k8s-install.sh
@@ -62,5 +62,8 @@ echo "Install and enable migration-remove-upgraded.service"
 cp /var/kubernetes/migration-remove-upgraded.service /usr/lib/systemd/system/
 systemctl enable migration-remove-upgraded.service
 
+echo "Disable systemd-resolved"
+printf "%s\n%s\n" '[Resolve]' 'DNSStubListener=no' | tee /etc/systemd/resolved.conf
+
 echo "Commit changes"
 ostree container commit


### PR DESCRIPTION
While k8s knows how to deal with systemd-resolved, it still causes more
problems that it solves when using chroot in pods.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>