### PR TITLE
renovate: Automerge frequent flyer patch updates

### DIFF
--- a/.github/renovate/automerge.json5
+++ b/.github/renovate/automerge.json5
@@ -13,5 +13,12 @@
       "matchPackagePatterns": ["kubernetes/kubernetes"],
       "automerge": false
     },
+    {
+      "description": "Auto merge frequent flyer packages on patch updates",
+      "matchPackagePatterns": ["golangci/golangci-lint", "docker/cli", "ghcr.io/heathcliff26/simple-fileserver"],
+      "matchUpdateTypes": ["patch"],
+      "automerge": true,
+      "automergeType": "branch"
+    },
   ]
 }


### PR DESCRIPTION
These packages have frequent patch updates. As they are not breaking changes, automerging should be fine.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>