### PR TITLE
openwrt-package-sync: Add signify

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![github-actions-runner](https://github.com/heathcliff26/containers/actions/workflows/build-github-actions-runner.yaml/badge.svg)](https://github.com/heathcliff26/containers/actions/workflows/build-github-actions-runner.yaml)
 [![go-fyne-ci](https://github.com/heathcliff26/containers/actions/workflows/build-go-fyne-ci.yaml/badge.svg)](https://github.com/heathcliff26/containers/actions/workflows/build-go-fyne-ci.yaml)
 [![keepalived](https://github.com/heathcliff26/containers/actions/workflows/build-keepalived.yaml/badge.svg)](https://github.com/heathcliff26/containers/actions/workflows/build-keepalived.yaml)
+[![openwrt-package-sync](https://github.com/heathcliff26/containers/actions/workflows/build-openwrt-package-sync.yaml/badge.svg)](https://github.com/heathcliff26/containers/actions/workflows/build-openwrt-package-sync.yaml)
 [![squid](https://github.com/heathcliff26/containers/actions/workflows/build-squid.yaml/badge.svg)](https://github.com/heathcliff26/containers/actions/workflows/build-squid.yaml)
 [![tang](https://github.com/heathcliff26/containers/actions/workflows/build-tang.yaml/badge.svg)](https://github.com/heathcliff26/containers/actions/workflows/build-tang.yaml)
 [![unbound](https://github.com/heathcliff26/containers/actions/workflows/build-unbound.yaml/badge.svg)](https://github.com/heathcliff26/containers/actions/workflows/build-unbound.yaml)

--- a/apps/openwrt-package-sync/Dockerfile
+++ b/apps/openwrt-package-sync/Dockerfile
@@ -7,6 +7,6 @@ LABEL   org.opencontainers.image.authors="heathcliff@heathcliff.eu" \
         org.opencontainers.image.title="openwrt-package-sync"
 
 RUN echo "@testing https://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories && \
-        apk add --no-cache opkg-utils@testing curl jq cosign@testing
+        apk add --no-cache opkg-utils@testing curl jq cosign@testing signify@testing
 
 USER 1001


### PR DESCRIPTION
Package index needs to be signed. Use signify.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>