### PR TITLE
fcos-k8s: Install cri-tools explicitly

### DIFF
--- a/apps/fcos-k8s/k8s-install.sh
+++ b/apps/fcos-k8s/k8s-install.sh
@@ -19,7 +19,7 @@ gpgkey=https://pkgs.k8s.io/core:/stable:/v${KUBERNETES_SHORT_VERSION}/rpm/repoda
 EOF
 
 echo "Install packages"
-rpm-ostree install "kubelet-${KUBERNETES_VERSION}" "kubeadm-${KUBERNETES_VERSION}" "kubectl-${KUBERNETES_VERSION}" "cri-o${CRIO_VERSION}"
+rpm-ostree install "kubelet-${KUBERNETES_VERSION}" "kubeadm-${KUBERNETES_VERSION}" "kubectl-${KUBERNETES_VERSION}" "cri-o${CRIO_VERSION}" "cri-tools${CRIO_VERSION}"
 rpm-ostree cleanup -m
 
 echo "Enable kubelet and crio services"


### PR DESCRIPTION
It seems the latest k8s rpms no longer install crictl. Install it explicitly instead.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>